### PR TITLE
Fixed error in der_strict_encode_sig()

### DIFF
--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -2,13 +2,13 @@ from .utils import (is_valid_hash, is_valid_block_representation,
         is_valid_coin_symbol, is_valid_address_for_coinsymbol,
         coin_symbol_from_mkey, double_sha256, compress_txn_outputs,
         get_txn_outputs_dict, uses_only_hash_chars)
-from .crypto import der_strict_encode_sig
 
 from .constants import COIN_SYMBOL_MAPPINGS
 
 from dateutil import parser
 
-from bitcoin import ecdsa_raw_sign, ecdsa_raw_verify, der_decode_sig, compress, privkey_to_pubkey, pubkey_to_address
+from bitcoin import ecdsa_raw_sign, ecdsa_raw_verify, der_decode_sig, compress, privkey_to_pubkey, pubkey_to_address, \
+    der_encode_sig
 
 import requests
 
@@ -1629,7 +1629,7 @@ def make_tx_signatures(txs_to_sign, privkey_list, pubkey_list):
 
     signatures = []
     for cnt, tx_to_sign in enumerate(txs_to_sign):
-        sig = der_strict_encode_sig(*ecdsa_raw_sign(tx_to_sign.rstrip(' \t\r\n\0'), privkey_list[cnt]))
+        sig = der_encode_sig(*ecdsa_raw_sign(tx_to_sign.rstrip(' \t\r\n\0'), privkey_list[cnt]))
         assert ecdsa_raw_verify(tx_to_sign, der_decode_sig(sig), pubkey_list[cnt])
         signatures.append(sig)
     return signatures

--- a/blockcypher/crypto.py
+++ b/blockcypher/crypto.py
@@ -2,24 +2,6 @@ from bitcoin import encode, changebase, binascii, bin_to_b58check
 
 import re
 
-
-def der_strict_encode_sig(v, r, s):
-    '''
-    Like der_encode_sig but bip66 compliant
-    Copied 2015-10-02 from https://github.com/wizardofozzie/pybitcointools/blob/36d4b4a323b78927f6c6487160194aeffd32c61d/bitcoin/transaction.py#L153-L164
-    Thanks @wizardofozzie!
-    '''
-    b1, b2 = encode(r, 256), encode(s, 256)
-    if ord(b1[0]) & 0x80:       # add null bytes if leading byte interpreted as negative
-        b1 = b'\0' + b1
-    if ord(b2[0]) & 0x80:
-        b2 = b'\0' + b2
-    left = b'\x02' + encode(len(b1), 256, 1) + b1
-    right = b'\x02' + encode(len(b2), 256, 1) + b2
-    sighex = changebase((b'\x30' + encode(len(left+right), 256, 1) + left + right), 256, 16)
-    return sighex
-
-
 def script_to_address(script, vbyte=0):
     '''
     Like script_to_address but supports altcoins

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='blockcypher',
       description='BlockCypher Python Library',
       author='Michael Flaxman',
       author_email='mflaxman+blockcypher@gmail.com',
-      url='https://github.com/blockcypher/blockcypher-python/',
+      url='https://github.com/michailbrynard/blockcypher-python/',
       install_requires=[
           'requests==2.4.3',
           'python-dateutil==2.2',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='blockcypher',
       install_requires=[
           'requests==2.4.3',
           'python-dateutil==2.2',
-          'bitcoin==1.1.29',
+          'bitcoin-1.1.38',
           ],
       packages=['blockcypher'],
       include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='blockcypher',
       description='BlockCypher Python Library',
       author='Michael Flaxman',
       author_email='mflaxman+blockcypher@gmail.com',
-      url='https://github.com/michailbrynard/blockcypher-python/',
+      url='https://github.com/blockcypher/blockcypher-python/',
       install_requires=[
           'requests==2.4.3',
           'python-dateutil==2.2',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='blockcypher',
       install_requires=[
           'requests==2.4.3',
           'python-dateutil==2.2',
-          'bitcoin-1.1.38',
+          'bitcoin==1.1.38',
           ],
       packages=['blockcypher'],
       include_package_data=True,


### PR DESCRIPTION
Updated to use der_encode_sig() from https://github.com/vbuterin/pybitcointools (v1.1.38) which is now BIP66 compliant.