### PR TITLE
Run tests with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7.10"
+  - "3.5.1"
+install: python setup.py develop
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+script:
+  - python test_blockcypher.py

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Designed to be used without having to RTFM.
 
 More features and support for more endpoints coming soon. Should support python 2.6+ and python3.x, but hasn't been thoroughly tested on 2.6+. Native support for datetime conversions. Issues and pull requests much appreciated!
 
+[![Build Status](https://travis-ci.org/blockcypher/blockcypher-python.svg?branch=master)](https://travis-ci.org/blockcypher/blockcypher-python)
 
 #### Installation
 


### PR DESCRIPTION
Pretty basic, but it covers Python 2.7.10 & 3.5.1.

Note the tests don't (yet) work consistently- they work sometimes, but rate limiting and unexpected responses from the server have yet to show a passing build on Travis. They also only work sporadically on my machine. 