### PR TITLE
modified signing and broadcasting tx to allow spending from multi-sig

### DIFF
--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -1753,8 +1753,6 @@ def broadcast_signed_transaction(unsigned_tx, signatures, pubkeys, coin_symbol='
         for idx, sig in enumerate(signatures):
             signature = [sig]
             pubkey = [pubkeys[idx]]
-            print('sig = {}'.format(signature))
-            print('pubkey = {}'.format(pubkey))
 
             data = unsigned_tx.copy()
             data['signatures'] = signature

--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -1679,7 +1679,7 @@ def get_input_addresses(unsigned_tx):
     return addresses
 
 
-def make_tx_signatures(txs_to_sign, privkey_list, pubkey_list):
+def make_tx_signatures(txs_to_sign, privkey_list, pubkey_list, tx_type='p2pkh'):
     """
     Loops through txs_to_sign and makes signatures using privkey_list and pubkey_list
 
@@ -1694,25 +1694,34 @@ def make_tx_signatures(txs_to_sign, privkey_list, pubkey_list):
     
     http://dev.blockcypher.com/#multisig-transactions
     """
-    assert len(privkey_list) == len(pubkey_list) == len(txs_to_sign)
-    # in the event of multiple inputs using the same pub/privkey,
-    # that privkey should be included multiple times
-
     signatures = []
-    for cnt, tx_to_sign in enumerate(txs_to_sign):
-        sig = der_encode_sig(*ecdsa_raw_sign(tx_to_sign.rstrip(' \t\r\n\0'), privkey_list[cnt]))
-        assert ecdsa_raw_verify(tx_to_sign, der_decode_sig(sig), pubkey_list[cnt])
-        signatures.append(sig)
+    if tx_type == 'p2pkh': # spending from 'normal' address
+        assert len(privkey_list) == len(pubkey_list) == len(txs_to_sign)
+        # in the event of multiple inputs using the same pub/privkey,
+        # that privkey should be included multiple times
+        for cnt, tx_to_sign in enumerate(txs_to_sign):
+            sig = der_encode_sig(*ecdsa_raw_sign(tx_to_sign.rstrip(' \t\r\n\0'), privkey_list[cnt]))
+            assert ecdsa_raw_verify(tx_to_sign, der_decode_sig(sig), pubkey_list[cnt])
+            signatures.append(sig)
+
+    elif tx_type == 'p2sh': # spending from multi-sig address
+        assert len(privkey_list) == len(pubkey_list)
+        # make sure that the list of privkeys is sorted the same way of the list 
+        # of pubkeys: for ex.: [priv1,priv3] and [pub1,pub3]
+        for cnt, each_privkey in enumerate(privkey_list):
+            tx_to_sign = txs_to_sign[0]
+            sig = der_encode_sig(*ecdsa_raw_sign(tx_to_sign.rstrip(' \t\r\n\0'), privkey_list[cnt]))
+            assert ecdsa_raw_verify(tx_to_sign, der_decode_sig(sig), pubkey_list[cnt])
+            signatures.append(sig)
+
     return signatures
 
 
-def broadcast_signed_transaction(unsigned_tx, signatures, pubkeys, coin_symbol='btc'):
+def broadcast_signed_transaction(unsigned_tx, signatures, pubkeys, coin_symbol='btc', tx_type='p2pkh'):
     '''
     Broadcasts the transaction from create_unsigned_tx
     '''
-    assert len(unsigned_tx['tosign']) == len(signatures)
     assert 'errors' not in unsigned_tx
-
     url = '%s/%s/%s/%s/txs/send' % (
             BLOCKCYPHER_DOMAIN,
             ENDPOINT_VERSION,
@@ -1721,18 +1730,45 @@ def broadcast_signed_transaction(unsigned_tx, signatures, pubkeys, coin_symbol='
             )
     logger.info(url)
 
-    data = unsigned_tx.copy()
-    data['signatures'] = signatures
-    data['pubkeys'] = pubkeys
+    if tx_type == 'p2pkh': # spending from 'normal' address
+        assert len(unsigned_tx['tosign']) == len(signatures)
 
-    r = requests.post(url, json=data, verify=True, timeout=TIMEOUT_IN_SECONDS)
+        data = unsigned_tx.copy()
+        data['signatures'] = signatures
+        data['pubkeys'] = pubkeys
 
-    response_dict = r.json()
+        r = requests.post(url, json=data, verify=True, timeout=TIMEOUT_IN_SECONDS)
 
-    if response_dict.get('tx') and response_dict.get('received'):
-        response_dict['tx']['received'] = parser.parse(response_dict['tx']['received'])
+        response_dict = r.json()
 
-    return response_dict
+        if response_dict.get('tx') and response_dict.get('received'):
+            response_dict['tx']['received'] = parser.parse(response_dict['tx']['received'])
+
+        return response_dict
+
+    if tx_type == 'p2sh': # spending from multisig address
+        assert len(signatures) == len(pubkeys)
+        response_dict_list = []
+        
+        for idx, sig in enumerate(signatures):
+            signature = [sig]
+            pubkey = [pubkeys[idx]]
+            print('sig = {}'.format(signature))
+            print('pubkey = {}'.format(pubkey))
+
+            data = unsigned_tx.copy()
+            data['signatures'] = signature
+            data['pubkeys'] = pubkey
+
+            r = requests.post(url, json=data, verify=True, timeout=TIMEOUT_IN_SECONDS)
+
+            response_dict = r.json()
+
+            if response_dict.get('tx') and response_dict.get('received'):
+                response_dict['tx']['received'] = parser.parse(response_dict['tx']['received'])
+
+            response_dict_list.append(response_dict)
+        return response_dict_list
 
 
 def simple_spend(from_privkey, to_address, to_satoshis, change_address=None,

--- a/test_blockcypher.py
+++ b/test_blockcypher.py
@@ -313,7 +313,6 @@ class UncompressedTXSign(unittest.TestCase):
         # confirm details (esp that change sent back to sender address)
         tx_details = get_transaction_details(tx_hash=tx_hash, coin_symbol='bcy')
 
-        print(tx_details)
         for input_obj in tx_details['inputs']:
             assert len(input_obj['addresses']) == 1, input_obj['addresses']
             assert input_obj['addresses'][0] == self.bcy_pub_addr

--- a/test_blockcypher.py
+++ b/test_blockcypher.py
@@ -313,6 +313,7 @@ class UncompressedTXSign(unittest.TestCase):
         # confirm details (esp that change sent back to sender address)
         tx_details = get_transaction_details(tx_hash=tx_hash, coin_symbol='bcy')
 
+        print(tx_details)
         for input_obj in tx_details['inputs']:
             assert len(input_obj['addresses']) == 1, input_obj['addresses']
             assert input_obj['addresses'][0] == self.bcy_pub_addr


### PR DESCRIPTION
Currently, using multisig address, if we want to spend from it, we can make the transaction, but the signing and broadcasting is limited:  we can only sign with one private key (used to generate the multisig address) after another:

```
# Example with a multisig generated with pub1, pub2 and pub3:
""" Siging with one of the privkey """
 tx_signatures = make_tx_signatures(txs_to_sign=unsigned_tx['tosign'], privkey_list=[priv1], pubkey_list=[pub1])
broadcast_signed_transaction(unsigned_tx, tx_signatures, [pub3], coin_symbol='btc-testnet')
"""" signing with the other privkey """
 tx_signatures = make_tx_signatures(txs_to_sign=unsigned_tx['tosign'], privkey_list=[priv3], pubkey_list=[pub3])
broadcast_signed_transaction(unsigned_tx, tx_signatures, [pub3], coin_symbol='btc-testnet')
```
this works, but the code below won't work  
```
 tx_signatures = make_tx_signatures(txs_to_sign=unsigned_tx['tosign'], privkey_list=[priv1,priv3], pubkey_list=[pub1,pub3])
broadcast_signed_transaction(unsigned_tx, tx_signatures, [pub1,pub3], coin_symbol='btc-testnet')
```
because the `txs_to_sign` will be of length `1` when the privkey and pubkey list will have 2 elements.

My solution is not very pretty (duplication of code, and default argument `tx_type` added into the function of `make_tx_signatures` and `broadcast_signed_transaction` ...
