### PR TITLE
Simple spend p2sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ We can also get details on its transaction(s):
  'tx_url': 'https://api.blockcypher.com/v1/btc/main/txs/'}
 ```
 
-Another cool feature is that we can generate a new address keypair server-side:
+Another cool feature is that we can generate a new address keypair server-side, but you should really do this client-side:
 ```
 >>> blockcypher.generate_new_address()
 {'public': '03c87d1bba027204670c975d01e813d4a20ba4f79500802ba0d51ce3393fb86c1f',
@@ -268,3 +268,6 @@ For example, here's the latest Litecoin block height.
 >>> blockcypher.get_latest_block_height(coin_symbol='ltc')
 678686
 ```
+
+#### Pull Requests Welcome
+Please note that all PRs require test coverage in `test_blockcypher.py`.

--- a/blockcypher/__init__.py
+++ b/blockcypher/__init__.py
@@ -76,6 +76,7 @@ from .api import get_input_addresses
 from .api import make_tx_signatures
 from .api import broadcast_signed_transaction
 from .api import simple_spend
+from .api import simple_spend_p2sh
 from .api import embed_data
 from .api import get_metadata
 from .api import put_metadata

--- a/blockcypher/constants.py
+++ b/blockcypher/constants.py
@@ -10,6 +10,8 @@ COIN_SYMBOL_ODICT_LIST = [
             'pow': 'sha',
             'example_address': '16Fg2yjwrbtC6fZp61EV9mNVKmwCzGasw5',
             'address_first_char_list': ('1', '3', '4'),
+            'singlesig_prefix_list': ('1', ),
+            'multisig_prefix_list': ('3', ),
             'first4_mprv': 'xprv',
             'first4_mpub': 'xpub',
             'vbyte_pubkey': 0,
@@ -25,6 +27,8 @@ COIN_SYMBOL_ODICT_LIST = [
             'pow': 'sha',
             'example_address': '2N1rjhumXA3ephUQTDMfGhufxGQPZuZUTMk',
             'address_first_char_list': ('m', 'n', '2', 'z'),
+            'singlesig_prefix_list': ('m', 'n', ),
+            'multisig_prefix_list': ('2', ),
             'first4_mprv': 'tprv',
             'first4_mpub': 'tpub',
             'vbyte_pubkey': 111,
@@ -40,6 +44,8 @@ COIN_SYMBOL_ODICT_LIST = [
             'pow': 'scrypt',
             'example_address': 'LcFFkbRUrr8j7TMi8oXUnfR4GPsgcXDepo',
             'address_first_char_list': ('L', 'U', '3', '4'),
+            'singlesig_prefix_list': ('L', ),
+            'multisig_prefix_list': ('3', ),
             'first4_mprv': 'Ltpv',
             'first4_mpub': 'Ltub',
             'vbyte_pubkey': 48,
@@ -55,6 +61,8 @@ COIN_SYMBOL_ODICT_LIST = [
             'pow': 'scrypt',
             'example_address': 'D7Y55r6Yoc1G8EECxkQ6SuSjTgGJJ7M6yD',
             'address_first_char_list': ('D', '9', 'A', '2'),
+            'singlesig_prefix_list': ('D', ),
+            'multisig_prefix_list': ('9', 'A', ),
             'first4_mprv': 'dgpv',
             'first4_mpub': 'dgub',
             'vbyte_pubkey': 30,
@@ -70,6 +78,8 @@ COIN_SYMBOL_ODICT_LIST = [
             'pow': 'sha',
             'example_address': 'CFr99841LyMkyX5ZTGepY58rjXJhyNGXHf',
             'address_first_char_list': ('B', 'C', 'D', 'Y'),
+            'singlesig_prefix_list': ('C', 'B', ),
+            'multisig_prefix_list': ('D', ),
             'first4_mprv': 'bprv',
             'first4_mpub': 'bpub',
             'vbyte_pubkey': 27,
@@ -87,6 +97,13 @@ REQUIRED_FIELDS = (
     'currency_abbrev',  # what the unit of currency looks like when abbreviated
     'pow',  # the proof of work algorithm (sha/scrypt)
     'example_address',  # an example address
+    'address_first_char_list',  # the list of first char possibilites for an address
+    'singlesig_prefix_list',  # the list of first char possibilities for a single signature address
+    'multisig_prefix_list',  # the list of first char possibilities for a multi signature address
+    'first4_mprv',  # first 4 chars of the master private key
+    'first4_mpub',  # first 4 chars of the master public key
+    'vbyte_pubkey',  # pubkey version byte
+    'vbyte_script',  # script hash version byte
     )
 
 ELIGIBLE_POW_ENTRIES = set(['sha', 'scrypt'])

--- a/blockcypher/utils.py
+++ b/blockcypher/utils.py
@@ -169,10 +169,11 @@ def get_txn_outputs(raw_tx_hex, output_addr_list, coin_symbol):
     for output_addr in output_addr_list:
         assert is_valid_address(output_addr), output_addr
 
+    output_addr_set = set(output_addr_list)  # speed optimization
+
     outputs = []
     deserialized_tx = deserialize(str(raw_tx_hex))
     for out in deserialized_tx.get('outs', []):
-        output_addr_set = set(output_addr_list)  # speed optimization
 
         # determine if the address is a pubkey address or a script address
         pubkey_addr = script_to_address(out['script'],

--- a/test_blockcypher.py
+++ b/test_blockcypher.py
@@ -9,6 +9,8 @@ from blockcypher import create_unsigned_tx
 
 import os
 
+from time import sleep
+
 
 BC_API_KEY = os.getenv('BC_API_KEY')
 
@@ -28,6 +30,15 @@ class TestUtils(unittest.TestCase):
 
 
 class GetAddressesDetails(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        if not BC_API_KEY:
+            # to avoid 429s in case of no API key
+            print('sleeping...')
+            sleep(5)
 
     def test_get_addresses_details(self):
         addresses_details = get_addresses_details(
@@ -67,6 +78,15 @@ class GetAddressesDetails(unittest.TestCase):
 
 class CreateUnsignedTX(unittest.TestCase):
 
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        if not BC_API_KEY:
+            # to avoid 429s in case of no API key
+            print('sleeping...')
+            sleep(5)
+
     def test_create_basic_unsigned(self):
         # This address I previously sent funds to but threw out the private key
         create_unsigned_tx(
@@ -76,11 +96,13 @@ class CreateUnsignedTX(unittest.TestCase):
                 outputs=[
                     {
                         'value': -1,
-                        'address': 'CFr99841LyMkyX5ZTGepY58rjXJhyNGXHf',
+                        # p2sh address for extra measure
+                        'address': 'Dbc9fnf1Kqct7zvfNTiwr6HjvDfPYaFSNg',
                         },
                     ],
                 change_address=None,
                 include_tosigntx=True,
+                # will test signature returned locally:
                 verify_tosigntx=True,
                 coin_symbol='bcy',
                 api_key=BC_API_KEY,
@@ -107,6 +129,7 @@ class CreateUnsignedTX(unittest.TestCase):
                     ],
                 change_address=None,
                 include_tosigntx=True,
+                # will test signature returned locally:
                 verify_tosigntx=True,
                 coin_symbol='bcy',
                 api_key=BC_API_KEY,
@@ -114,6 +137,15 @@ class CreateUnsignedTX(unittest.TestCase):
 
 
 class GetAddressDetails(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        if not BC_API_KEY:
+            # to avoid 429s in case of no API key
+            print('sleeping...')
+            sleep(5)
 
     def test_fetching_unspents(self):
         # This address I previously sent funds to but threw out the private key
@@ -184,6 +216,12 @@ class CompressedTXSign(unittest.TestCase):
 
         # Generation steps:
         # $ curl -X POST https://api.blockcypher.com/v1/bcy/test/addrs
+
+    def tearDown(self):
+        if not BC_API_KEY:
+            # to avoid 429s in case of no API key
+            print('sleeping...')
+            sleep(5)
 
     def test_simple_spend_hex(self):
         tx_hash = simple_spend(
@@ -270,6 +308,12 @@ class UncompressedTXSign(unittest.TestCase):
         wallet.public_key.get_key(compressed=False)
         wallet.public_key.to_address(compressed=False)
         '''
+
+    def tearDown(self):
+        if not BC_API_KEY:
+            # to avoid 429s in case of no API key
+            print('sleeping...')
+            sleep(5)
 
     def test_simple_spend_hex(self):
         tx_hash = simple_spend(


### PR DESCRIPTION
- Introduce simple_spend_p2sh to fix #39 
- Add sleep to test cases to avoid 429s when used without an API key
- Add single/multi key address prefix for utility methods
- Cleanup docs