### PR TITLE
fix for null-data not needing an address assertion

### DIFF
--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -1654,6 +1654,7 @@ def create_unsigned_tx(inputs, outputs, change_address=None,
 
         # no address required for null-data outputs
         if output.get('script_type') == 'null-data':
+            assert output['value'] == 0
             assert 'script' in output, output
             clean_output['script_type'] = 'null-data'
             clean_output['script'] = output['script']
@@ -1754,7 +1755,7 @@ def verify_unsigned_tx(unsigned_tx, outputs, inputs=None, sweep_funds=False,
         err_msg = 'tosign_tx not in API response:\n%s' % unsigned_tx
         return False, err_msg
 
-    output_addr_list = [x['address'] for x in outputs]
+    output_addr_list = [x['address'] for x in outputs if x.get('address') != None]
     if change_address:
         output_addr_list.append(change_address)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='blockcypher',
-      version='1.0.71',
+      version='1.0.72',
       description='BlockCypher Python Library',
       author='Michael Flaxman',
       author_email='mflaxman+blockcypher@gmail.com',

--- a/test_blockcypher.py
+++ b/test_blockcypher.py
@@ -128,6 +128,28 @@ class CreateUnsignedTX(unittest.TestCase):
                 api_key=BC_API_KEY,
                 )
 
+    def test_create_nulldata_unsigned(self):
+        # This address I previously sent funds to but threw out the private key
+        create_unsigned_tx(
+                inputs=[
+                    {'address': 'BwvSPyMWVL1gkp5FZdrGXLpHj2ZJyJYLVB'},
+                    ],
+                outputs=[
+                    # embed some null-data
+                    {
+                        'value': 0,
+                        'script_type': 'null-data',
+                        'script': '6a06010203040506',
+                        },
+                    ],
+                change_address='CFr99841LyMkyX5ZTGepY58rjXJhyNGXHf',
+                include_tosigntx=True,
+                # will test signature returned locally:
+                verify_tosigntx=True,
+                coin_symbol='bcy',
+                api_key=BC_API_KEY,
+                )
+
 
 class GetAddressDetails(unittest.TestCase):
 


### PR DESCRIPTION
A customer was trying to use the create_unsigned_tx function to add a null-data output, and in the process of debugging I realized it was being a bit aggressive on assertions. Thanks to @hbcheng for helping me come up with this fix!