### PR TITLE
standardise json handling; use isinstance and list comprehensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-blockypher-python
+blockcypher-python
 =============
 
 Official python library for BlockCypher web services. Easily query the blockchain without writing any code. Fast, reliable, and packed with powerful features you won't find in other block explorers. Currently supports bitcoin (including main and testnet), Litecoin, Dogecoin, Dash, URO and the blockcypher testnet.

--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -1952,7 +1952,7 @@ def simple_spend_p2sh(all_from_pubkeys, from_privkeys_to_use, to_address, to_sat
     assert isinstance(all_from_pubkeys, (list, tuple))
     assert len(all_from_pubkeys) > 1
 
-    assert isinstance(from_privkeys_to_use, (list, tuple)) from_privkeys_to_use
+    assert isinstance(from_privkeys_to_use, (list, tuple)), from_privkeys_to_use
 
     for from_privkey in from_privkeys_to_use:
         from_pubkey = compress(privkey_to_pubkey(from_privkey))

--- a/blockcypher/utils.py
+++ b/blockcypher/utils.py
@@ -104,7 +104,7 @@ def format_crypto_units(input_quantity, input_type, output_type, coin_symbol=Non
     assert output_type in UNIT_CHOICES, output_type
     if print_cs:
         assert is_valid_coin_symbol(coin_symbol=coin_symbol), coin_symbol
-    assert type(round_digits) is int
+    assert isinstance(round_digits, int)
 
     satoshis_float = to_satoshis(input_quantity=input_quantity, input_type=input_type)
 
@@ -165,7 +165,7 @@ def get_txn_outputs(raw_tx_hex, output_addr_list, coin_symbol):
     # Defensive checks:
     err_msg = 'Library not able to parse %s transactions' % coin_symbol
     assert lib_can_deserialize_cs(coin_symbol), err_msg
-    assert type(output_addr_list) in (list, tuple)
+    assert isinstance(output_addr_list, (list, tuple))
     for output_addr in output_addr_list:
         assert is_valid_address(output_addr), output_addr
 
@@ -178,9 +178,9 @@ def get_txn_outputs(raw_tx_hex, output_addr_list, coin_symbol):
 
         # determine if the address is a pubkey address, script address, or op_return
         pubkey_addr = script_to_address(out['script'],
-                vbyte=COIN_SYMBOL_MAPPINGS[coin_symbol]['vbyte_pubkey'])
+            vbyte=COIN_SYMBOL_MAPPINGS[coin_symbol]['vbyte_pubkey'])
         script_addr = script_to_address(out['script'],
-                vbyte=COIN_SYMBOL_MAPPINGS[coin_symbol]['vbyte_script'])
+            vbyte=COIN_SYMBOL_MAPPINGS[coin_symbol]['vbyte_script'])
         nulldata = out['script'] if out['script'][0:2] == '6a' else None
         if pubkey_addr in output_addr_set:
             address = pubkey_addr


### PR DESCRIPTION
We bumped into a `json.decoder.JSONDecodeError: Expecting value: line 1 column 1`, which came from one of one of your `r.json()` calls.

This PR puts all of these calls inside a single function, allowing 204 to return True in the cases where it already did,  still checking for rate limits, and now raises `requests.exceptions.ContentDecodingError` with a a more useful message.

Other changes: use of `isinstance` (preferred over `type`) and reduction of some loops into list comprehensions. I also compressed the large chunks of code that were generating URLs, making a simple function for this instead.

Tests pass, too. Merge please :)