### PR TITLE
Accept dateutil and requests versions lower than 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='blockcypher',
-      version='1.0.73',
+      version='1.0.74',
       description='BlockCypher Python Library',
       author='Michael Flaxman',
       author_email='mflaxman+blockcypher@gmail.com',
       url='https://github.com/blockcypher/blockcypher-python/',
       install_requires=[
-          'requests==2.4.3',
-          'python-dateutil==2.2',
+          'requests<3.0.0',
+          'python-dateutil<3.0.0',
           'bitcoin==1.1.39',
           ],
       packages=['blockcypher'],


### PR DESCRIPTION
There's no breaking change expected until 3 comes to both pkgs:  
- 'requests < 3.0.0', http://docs.python-requests.org/en/master/community/release-process/  
- 'python-dateutil < 3.0.0', https://github.com/dateutil/dateutil/milestones