### PR TITLE
delete_wallet make_url  fix

### DIFF
--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -1264,8 +1264,8 @@ def delete_wallet(wallet_name, api_key, is_hd_wallet=False, coin_symbol='btc'):
     assert is_valid_wallet_name(wallet_name), wallet_name
 
     params = {'token': api_key}
-    wallet = {'hd/' if is_hd_wallet else '': wallet_name}
-    url = make_url(coin_symbol, wallet)
+    wallet = {'wallets/hd/' if is_hd_wallet else 'wallets': wallet_name}
+    url = make_url(coin_symbol, **wallet)
     r = requests.delete(url, params=params, verify=True, timeout=TIMEOUT_IN_SECONDS)
     return get_valid_json(r, allow_204=True)
 


### PR DESCRIPTION
```
  File "test_blockcypher.py", line 512, in test_register_btc_wallet
    api_key=BC_API_KEY, is_hd_wallet=True)
  File "/home/daz/projects/OS/blockcypher-python/blockcypher/api.py", line 1267, in delete_wallet
    url = make_url(coin_symbol, wallet)
  File "/home/daz/projects/OS/blockcypher-python/blockcypher/api.py", line 1861, in make_url
    url = os.path.join(*url_bits)
  File "/usr/lib/python3.7/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.7/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'dict'
```