### PR TITLE
Fix wrong url path on Windows

### DIFF
--- a/blockcypher/api.py
+++ b/blockcypher/api.py
@@ -22,6 +22,7 @@ from .utils import uses_only_hash_chars
 from .constants import COIN_SYMBOL_MAPPINGS
 
 from dateutil import parser
+from posixpath import join as urljoin
 
 import requests
 
@@ -1858,7 +1859,7 @@ def make_url(coin_symbol, simple_string=False, meta=False, **kwargs):
     if meta:
         url_bits.append('meta')
 
-    url = os.path.join(*url_bits)
+    url = urljoin(*url_bits)
 
     logger.info(url)
     return url

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='blockcypher',
-      version='1.0.79',
+      version='1.0.80',
       description='BlockCypher Python Library',
       author='Michael Flaxman',
       author_email='mflaxman+blockcypher@gmail.com',


### PR DESCRIPTION
Fix https://github.com/blockcypher/blockcypher-python/issues/79.
Bump to 1.0.80.