### PR TITLE
maddrs fix for LTC

### DIFF
--- a/blockcypher/constants.py
+++ b/blockcypher/constants.py
@@ -71,7 +71,7 @@ COIN_SYMBOL_ODICT_LIST = [
             'first4_mprv': 'Ltpv',
             'first4_mpub': 'Ltub',
             'vbyte_pubkey': 48,
-            'vbyte_script': 5,
+            'vbyte_script': 50,
             },
         {
             'coin_symbol': 'doge',


### PR DESCRIPTION
Fixed an error where a computed P2SH from script would start with 3 (legacy) instead of M.